### PR TITLE
Fix setting incorrect node engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "promise"
   ],
   "engines": {
-    "node": "^10.0.0",
-    "yarn": "^1.0.0"
+    "node": ">=10",
+    "yarn": ">=1"
   },
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",


### PR DESCRIPTION
This is going to fix the following error:

```
yarn add v1.22.10
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
error paginate-generator@1.2.7: The engine "node" is incompatible with this module. Expected version "^10.0.0". Got "14.17.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

